### PR TITLE
Update webpack common config

### DIFF
--- a/client/webpack/common.config.js
+++ b/client/webpack/common.config.js
@@ -1,12 +1,6 @@
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-const webpack = require("webpack");
-const dotenv = require("dotenv");
-
-const env = dotenv.config().parsed;
-const envKeys = Object.keys(env).reduce((prev, next) => {
-	prev[`process.env.${next}`] = JSON.stringify(env[next]);
-	return prev;
-}, {});
+const { DefinePlugin, EnvironmentPlugin } = require("webpack");
+require("dotenv").config();
 
 module.exports = {
 	entry: "./client/src/index.js",
@@ -40,6 +34,11 @@ module.exports = {
 			favicon: "./client/src/favicon.ico",
 			template: "./client/src/index.html",
 		}),
-		new webpack.DefinePlugin(envKeys),
+		new DefinePlugin({
+			"process.env.REACT_APP_AUTH0_CLIENT_ID": JSON.stringify(process.env.REACT_APP_AUTH0_CLIENT_ID),
+			"process.env.REACT_APP_AUTH0_DOMAIN": JSON.stringify(process.env.REACT_APP_AUTH0_DOMAIN),
+			"process.env.REACT_APP_sUser_EMAIL": JSON.stringify(process.env.REACT_APP_sUser_EMAIL),
+			"process.env.REACT_APP_sUser_GITHUB": JSON.stringify(process.env.REACT_APP_sUser_GITHUB),
+		}),
 	],
 };


### PR DESCRIPTION
## What?
This PR fixes the way we access config on the client. I followed the steps in [the wiki here](https://github.com/textbook/starter-kit/wiki/Dotenv#Client-environment-variables).

I also made it so we only expose the variables that we need to the client.

## Why?
This was a LOT harder than it should have been and I wanted to unblock the team so that they can focus on the project and not get lost [down webpack rabbit holes](https://stackoverflow.com/a/65264701).

I also wanted to make sure we only expose specific env vars to the client
